### PR TITLE
cheap fix to dirtyexit -> jobs dropped problem

### DIFF
--- a/lib/resque/failure/multiple_with_retry_suppression.rb
+++ b/lib/resque/failure/multiple_with_retry_suppression.rb
@@ -33,7 +33,7 @@ module Resque
         retryable = retryable?
         job_being_retried = retryable && retrying?
 
-        if !job_being_retried
+        if exception.is_a?(Resque::DirtyExit) || !job_being_retried
           log_message "#{retryable ? '' : 'non-'}retriable job is not being retried - sending failure to superclass", args_from(payload), exception
           cleanup_retry_failure_log!
           super


### PR DESCRIPTION
Some jobs are getting dropped when their processes are being killed. The DirtyExit stuff that is supposed to handle killed processes isn't working; somehow, the jobs are neither being sent to the failed queue, nor being retried. I haven't figured out exactly what the bug is, although I have reproduced it. For now, this should make sure that we are conservative and send these jobs to the failed queue.